### PR TITLE
save babel plugin options on the server

### DIFF
--- a/src/settings/view.tsx
+++ b/src/settings/view.tsx
@@ -142,6 +142,7 @@ const SettingsGroup = styled.div`
   border-bottom: 1px solid #ddd;
   grid-column: 3 / span 1;
   grid-row: 2 / span 1;
+  overflow-x: auto;
 
   @media (max-width: 699px) {
     grid-column: 1 / span 1;

--- a/src/share/controller.tsx
+++ b/src/share/controller.tsx
@@ -13,15 +13,15 @@ import React from 'react'
 
 import {isShareAPISupported} from '../device'
 import {$sourceCode} from '../editor/state'
-import {shareCode} from '../graphql'
+import {shareCodeFx} from '../graphql'
 import {setCurrentShareId} from './index'
 
 export const pressCtrlS = createEvent()
 
 guard({
   source: pressCtrlS,
-  filter: shareCode.pending.map(pending => !pending),
-  target: shareCode,
+  filter: shareCodeFx.pending.map(pending => !pending),
+  target: shareCodeFx,
 })
 
 document.addEventListener(
@@ -35,7 +35,7 @@ document.addEventListener(
   false,
 )
 
-shareCode.done.watch(({result: {slug}}) => {
+shareCodeFx.done.watch(({result: {slug}}) => {
   // if (/https\:\/\/(share\.)?effector\.dev/.test(location.origin)) {
   history.pushState({slug}, slug, `${location.origin}/${slug}`)
   setCurrentShareId(slug)
@@ -43,14 +43,14 @@ shareCode.done.watch(({result: {slug}}) => {
 })
 
 const slug = createStore('').on(
-  shareCode.done,
+  shareCodeFx.done,
   (state, {result}) => result.slug,
 )
 export const sharedUrl: Store<string> = createStore('').on(
   slug,
   (state, slug) => `${location.origin}/${slug}`,
 )
-shareCode.fail.watch(e => console.log('fail', e))
+shareCodeFx.fail.watch(e => console.log('fail', e))
 
 export const canShare: Store<boolean> = slug.map(url => url !== '')
 

--- a/src/share/init.tsx
+++ b/src/share/init.tsx
@@ -1,3 +1,9 @@
+import {combine, forward, sample, split} from 'effector'
+import md5 from 'js-md5'
+
+import {$githubUser} from '~/github/state'
+import {getShareListByAuthorFx, shareCodeFx} from '~/graphql'
+
 import {
   addShare,
   onKeyDown,
@@ -6,7 +12,7 @@ import {
   setCurrentShareId,
   setFilterMode,
 } from './index'
-import md5 from 'js-md5'
+import {SharedItem} from './index.h'
 import {
   $currentShareId,
   $filterMode,
@@ -14,10 +20,6 @@ import {
   $shareDescription,
   $shareList,
 } from './state'
-import {combine, forward, sample, split} from 'effector'
-import {getShareListByAuthor, shareCode} from '~/graphql'
-import {$githubUser} from '~/github/state'
-import {SharedItem} from './index.h'
 
 $currentShareId.on(setCurrentShareId, (_, id) => id)
 
@@ -28,12 +30,12 @@ export const keyDown = split(onKeyDown, {
 
 forward({
   from: keyDown.Enter,
-  to: shareCode,
+  to: shareCodeFx,
 })
 
 $shareDescription.on(onTextChange, (_, value) => value).reset(keyDown.Escape)
 
-$shareList.on(getShareListByAuthor.done, (state, {params, result}) => {
+$shareList.on(getShareListByAuthorFx.done, (state, {params, result}) => {
   return {
     ...state,
     [params.author]: result.pages
@@ -131,7 +133,7 @@ export const $sortedShareList = combine(
 
 $githubUser.watch(({databaseId}) => {
   if (databaseId) {
-    getShareListByAuthor({author: databaseId})
+    getShareListByAuthorFx({author: databaseId})
   }
 })
 

--- a/src/share/view.tsx
+++ b/src/share/view.tsx
@@ -1,11 +1,19 @@
-import React from 'react'
-import {styled} from 'linaria/react'
 import {useStore} from 'effector-react'
+import {styled} from 'linaria/react'
+import React from 'react'
 
-import {getShareListByAuthor, shareCode} from '../graphql'
-import {sharing} from './controller'
-import {Section} from '../settings/view'
+import {theme} from '~/features/logs/lib/console/theme'
+import {getUserInfo} from '~/github/init'
+import {$debouncedInput} from '~/share/debounceInput'
+
+import {IconButton} from '../components/IconButton'
+import {CopyIcon} from '../components/Icons/CopyIcon'
+import {LoadingIcon} from '../components/Icons/LoadingIcon'
+import {ShareIcon} from '../components/Icons/ShareIcon'
 import {isShareAPISupported} from '../device'
+import {getShareListByAuthorFx, shareCodeFx} from '../graphql'
+import {Section} from '../settings/view'
+import {sharing} from './controller'
 import {
   handleInput,
   handleKeyDown,
@@ -14,20 +22,13 @@ import {
   setCurrentShareId,
   setFilterMode,
 } from './index'
-import {$currentShareId, $filterMode, $shareDescription} from './state'
-import {CopyIcon} from '../components/Icons/CopyIcon'
-import {ShareIcon} from '../components/Icons/ShareIcon'
-import {LoadingIcon} from '../components/Icons/LoadingIcon'
 import {$sortedShareList} from './init'
-import {IconButton} from '../components/IconButton'
-import {theme} from '~/features/logs/lib/console/theme'
-import {getUserInfo} from '~/github/init'
-import {$debouncedInput} from '~/share/debounceInput'
+import {$currentShareId, $filterMode, $shareDescription} from './state'
 
 const Save = ({disabled}: {disabled: boolean}) => {
-  const pending = useStore(shareCode.pending)
+  const pending = useStore(shareCodeFx.pending)
   return (
-    <ShareButton onClick={shareCode} disabled={disabled || pending}>
+    <ShareButton onClick={shareCodeFx} disabled={disabled || pending}>
       {pending && <LoadingIcon style={{marginRight: 10}} />}
       Save app
     </ShareButton>
@@ -233,7 +234,7 @@ const timeStringFormatter = new Intl.DateTimeFormat(['en-US'], {
 const ShareList = ({filterMode, description}) => {
   let sortedShareList = useStore($sortedShareList)
   const currentShareId = useStore($currentShareId)
-  const loading = useStore(getShareListByAuthor.pending)
+  const loading = useStore(getShareListByAuthorFx.pending)
   const signing = useStore(getUserInfo.pending)
   const isEmpty = sortedShareList.length === 0
 
@@ -353,7 +354,7 @@ const ValidatedInput = styled.input`
 
 export const Share = () => {
   const shareDescription = useStore($shareDescription)
-  const saving = useStore(shareCode.pending)
+  const saving = useStore(shareCodeFx.pending)
   const filterMode = useStore($filterMode)
   const descRef = React.useRef<HTMLInputElement>(null)
   const debouncedInput = useStore($debouncedInput)


### PR DESCRIPTION
Merge after @zerobias deploys the sharenow changes

- [ ] Check up loading babelPluginOptions back to store in:
  - when loading url share.effector.dev/SLUG
  - when loading share on click from share list