### PR TITLE
feature: Add solid-js support to repl

### DIFF
--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -5,6 +5,7 @@ export const evalFx: Effect<string, any, any> = createEffect()
 export const changeSources: Event<string> = createEvent()
 
 export const selectVersion: Event<string> = createEvent()
+export const selectViewLib: Event<string> = createEvent()
 
 export const codeSetCursor: Event<any> = createEvent()
 export const codeCursorActivity: Event<any> = createEvent()

--- a/src/editor/init.tsx
+++ b/src/editor/init.tsx
@@ -1,9 +1,9 @@
 import {forward, sample} from 'effector'
 
-import {changeSources, evalFx, selectVersion} from '.'
+import {changeSources, evalFx, selectVersion, selectViewLib} from '.'
 
 import {evaluator, versionLoader} from '../evaluator'
-import {$babelPluginSettings, $typechecker} from '../settings/state'
+import {$babelPluginSettings, $typechecker, $viewLib} from '../settings/state'
 import {compress} from './compression'
 import {retrieveCode, retrieveVersion} from './retrieve'
 import {$codeError, $sourceCode, $version} from './state'
@@ -11,6 +11,7 @@ import {$codeError, $sourceCode, $version} from './state'
 evalFx.use(evaluator)
 
 $version.on(selectVersion, (_, p) => p)
+$viewLib.on(selectViewLib, (_, p) => p)
 
 $codeError
   .on(evalFx.done, () => ({
@@ -68,7 +69,13 @@ forward({
 
 sample({
   source: $sourceCode,
-  clock: [$sourceCode, versionLoader, $typechecker, $babelPluginSettings],
+  clock: [
+    $sourceCode,
+    versionLoader,
+    $viewLib,
+    $typechecker,
+    $babelPluginSettings,
+  ],
   target: evalFx,
 })
 

--- a/src/editor/state.tsx
+++ b/src/editor/state.tsx
@@ -3,10 +3,12 @@ import {createStore} from 'effector'
 import {StackFrame} from '../evaluator/stackframe/stack-frame'
 import {$typechecker} from '../settings/state'
 import defaultVersions from '../versions.json'
+import defaultViewLibraries from '../viewLibraries.json'
 import {retrieveCode} from './retrieve'
 
 export const $version = createStore(defaultVersions[0])
 export const $packageVersions = createStore(defaultVersions)
+export const $viewLibraries = createStore(defaultViewLibraries)
 export const $sourceCode = createStore(retrieveCode())
 export const $compiledCode = createStore('')
 export const $codeError = createStore<

--- a/src/evaluator/prepareRuntime.tsx
+++ b/src/evaluator/prepareRuntime.tsx
@@ -1,8 +1,3 @@
-import * as Effector from 'effector'
-import * as EffectorReact from 'effector-react'
-import React from 'react'
-import * as ReactDOM from 'react-dom'
-
 // TODO: remove exact dependency on feature, use requirements in the future
 import {consoleMap} from '~/features/logs'
 
@@ -14,7 +9,7 @@ import {
   realmClearTimeout,
 } from '../realm'
 
-export function prepareRuntime(effector, effectorReact, version: string) {
+export function prepareRuntime(effector, initViewLib, version: string) {
   const api = {}
   apiMap(api, {
     createEvent: effector.createEvent,
@@ -33,14 +28,11 @@ export function prepareRuntime(effector, effectorReact, version: string) {
     clearNode: effector.clearNode,
     _withFactory: effector.withFactory, // TODO: fix babel plugin
   })
-  apiMap(api, {
-    createComponent: effectorReact.createComponent,
-  })
+  const {lib, env} = initViewLib(apiMap, api)
   assignLibrary(api, effector)
-  assignLibrary(api, effectorReact)
+  assignLibrary(api, lib)
   return {
-    React,
-    ReactDOM,
+    ...env,
     console: consoleMap(),
     setInterval,
     setTimeout,

--- a/src/evaluator/runtime.tsx
+++ b/src/evaluator/runtime.tsx
@@ -79,6 +79,7 @@ export async function exec({
       throw error
     }
   }
+  writeStuckFlag(true)
   try {
     const result = await realmGlobal.eval(compiled)
     if (onRuntimeComplete) await onRuntimeComplete()

--- a/src/features/logs/requirements.ts
+++ b/src/features/logs/requirements.ts
@@ -6,6 +6,11 @@ export const sourcesChanged = createEvent<string>()
 /** When effector version changed in UI */
 export const versionChanged = createEvent<string>()
 
+/**
+ * When view library changed in UI (react/solid)
+ */
+export const viewLibraryChanged = createEvent<string>()
+
 export const realmActiveChanged = createEvent<boolean>()
 
 export const autoScrollLogChanged = createEvent<boolean>()

--- a/src/init.tsx
+++ b/src/init.tsx
@@ -7,7 +7,7 @@ import './share/init'
 import './editor/init'
 
 import {$autoScrollLog} from './settings/state'
-import {changeSources, selectVersion} from './editor'
+import {changeSources, selectVersion, selectViewLib} from './editor'
 import {realmStatus} from './realm'
 
 import {
@@ -19,6 +19,7 @@ import {
 forward({from: $autoScrollLog, to: logs.autoScrollLogChanged})
 forward({from: changeSources, to: logs.sourcesChanged})
 forward({from: selectVersion, to: logs.versionChanged})
+forward({from: selectViewLib, to: logs.viewLibraryChanged})
 forward({
   from: realmStatus.map(status => status.active),
   to: logs.realmActiveChanged,

--- a/src/realm/init.tsx
+++ b/src/realm/init.tsx
@@ -1,6 +1,5 @@
 import {is} from 'effector'
 
-import {changeSources, selectVersion} from '../editor'
 import {
   realmClearNode,
   realmInvoke,
@@ -18,6 +17,7 @@ import {
   realmRemoveListener,
 } from '.'
 
+import {changeSources, selectVersion, selectViewLib} from '../editor'
 import {$intervals, $timeouts, $listeners, $stats} from './state'
 
 $listeners
@@ -41,23 +41,33 @@ $listeners
     }
     return []
   })
+  .on(selectViewLib, listeners => {
+    for (const {type, target, fn, options} of listeners) {
+      target.removeEventListener.__original__(type, fn, options)
+    }
+    return []
+  })
 
 $intervals
   .on(realmInterval, (state, id) => [...state, id])
   .on(realmClearInterval, (state, removed) =>
     state.filter(id => id !== removed),
   )
-  .on([changeSources, selectVersion], state => {
-
+  .on([changeSources, selectVersion, selectViewLib], state => {
     return []
   })
 
-$intervals.watch(changeSources, (state) => {
+$intervals.watch(changeSources, state => {
   for (const id of state) {
     global.clearInterval(id)
   }
 })
-$intervals.watch(selectVersion, (state) => {
+$intervals.watch(selectVersion, state => {
+  for (const id of state) {
+    global.clearInterval(id)
+  }
+})
+$intervals.watch(selectViewLib, state => {
   for (const id of state) {
     global.clearInterval(id)
   }
@@ -66,16 +76,21 @@ $intervals.watch(selectVersion, (state) => {
 $timeouts
   .on(realmTimeout, (state, id) => [...state, id])
   .on(realmClearTimeout, (state, removed) => state.filter(id => id !== removed))
-  .on([changeSources, selectVersion], state => {
+  .on([changeSources, selectVersion, selectViewLib], state => {
     return []
   })
 
-$timeouts.watch(changeSources, (state) => {
+$timeouts.watch(changeSources, state => {
   for (const id of state) {
     global.clearTimeout(id)
   }
 })
-$timeouts.watch(selectVersion, (state) => {
+$timeouts.watch(selectVersion, state => {
+  for (const id of state) {
+    global.clearTimeout(id)
+  }
+})
+$timeouts.watch(selectViewLib, state => {
   for (const id of state) {
     global.clearTimeout(id)
   }
@@ -150,6 +165,7 @@ $stats
   })
   .reset(changeSources)
   .reset(selectVersion)
+  .reset(selectViewLib)
 
 realmInvoke.watch(({method, params, instance}) => {
   if (method === 'restore') {

--- a/src/settings/state.tsx
+++ b/src/settings/state.tsx
@@ -13,6 +13,7 @@ export const $debugSids = localStorageSync.createStore<boolean | null>(null)
 export const $factories = localStorageSync.createStore<string[]>([])
 export const $importName = localStorageSync.createStore<string | null>(null)
 export const $reactSsr = localStorageSync.createStore<boolean | null>(null)
+export const $viewLib = localStorageSync.createStore<string>('react')
 
 export const $babelPluginSettings = combine(
   {

--- a/src/settings/view.tsx
+++ b/src/settings/view.tsx
@@ -13,14 +13,15 @@ import {
 } from '.'
 
 import {LoadingIcon} from '../components/Icons/LoadingIcon'
-import {selectVersion} from '../editor'
-import {$packageVersions, $version} from '../editor/state'
+import {selectVersion, selectViewLib} from '../editor'
+import {$packageVersions, $version, $viewLibraries} from '../editor/state'
 import {
   $addNames,
   $debugSids,
   $factories,
   $importName,
   $reactSsr,
+  $viewLib,
 } from '../settings/state'
 
 export const PrettifyButton = () => {
@@ -47,7 +48,8 @@ export const PrettifyButton = () => {
         alignItems: 'center',
         fontSize: 14,
         justifyContent: 'center',
-      }}>
+      }}
+    >
       {pending && <LoadingIcon style={{marginRight: 10}} />}
       Prettify
     </Button>
@@ -61,13 +63,29 @@ export const Settings = () => (
         <div className="versions">
           <select
             value={useStore($version)}
-            onChange={e => selectVersion(e.currentTarget.value)}>
+            onChange={e => selectVersion(e.currentTarget.value)}
+          >
             {useList($packageVersions, item => (
               <option value={item}>{item}</option>
             ))}
           </select>
         </div>
         Effector version
+      </Label>
+    </Section>
+    <Section>
+      <Label>
+        <div>
+          <select
+            value={useStore($viewLib)}
+            onChange={e => selectViewLib(e.currentTarget.value)}
+          >
+            {useList($viewLibraries, item => (
+              <option value={item}>{item}</option>
+            ))}
+          </select>
+        </div>
+        View library
       </Label>
     </Section>
     <Section>

--- a/src/viewLibraries.json
+++ b/src/viewLibraries.json
@@ -1,0 +1,1 @@
+["react", "solid"]


### PR DESCRIPTION
This pull request enables batteries-included approach to prototyping with solid. When viewLibrary is set to solid, global env has all the exports from solid-js, solid-js/web and effector-solid.